### PR TITLE
Allow non-scalar directive arguments and variables

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ import {
 } from '../src/index';
 import {
   GraphQLInt,
+  GraphQLInputObjectType,
   GraphQLSchema,
-  GraphQLObjectType,
   GraphQLNonNull,
   GraphQLList,
   graphql,
@@ -21,14 +21,34 @@ import {
 
 import {expect} from 'chai';
 
+const TestOption = new GraphQLInputObjectType({
+  name: 'TestOption',
+  fields: {
+    againBy: {
+      type: GraphQLInt,
+      description: 'then duplicate again this many times',
+    },
+  }
+});
+
 let GraphQLTestDirective,
-  GraphQLTestDirectiveTrows,
+  GraphQLTestDirectiveThrows,
   GraphQLTestDirectiveCatch,
   errors,
   schema;
 
 describe('GraphQLCustomDirective', () => {
   before(() => {
+    function doDuplicate(input, by) {
+      let times = [];
+
+      for (let i = 0; i < (by || 2); i++) {
+        times.push(input);
+      }
+
+      return times.join(' ');
+    }
+
     GraphQLTestDirective = new GraphQLCustomDirective({
       name: 'duplicate',
       description: 'duplicate the string sperating them with space',
@@ -38,24 +58,26 @@ describe('GraphQLCustomDirective', () => {
           type: GraphQLInt,
           description: 'the times to duplicate the string',
         },
+	      opts: {
+          type: new GraphQLList(TestOption),
+          description: 'additional options',
+	      }
       },
-      resolve: function(resolve, source, {by}, schema, info) {
+      resolve: function(resolve, source, {by, opts}, schema, info) {
         return resolve().then(result => {
-          if (!result) {
-            return result;
+          if (result) {
+            result = doDuplicate(result, by);
+            if (opts) {
+              for (let i = 0; i < opts.length; i++) {
+                result = doDuplicate(result, opts[i].againBy);
+              }
+            }
           }
-
-          let times = [];
-
-          for (let i = 0; i < (by || 2); i++) {
-            times.push(result);
-          }
-
-          return times.join(' ');
+          return result;
         });
       },
     });
-    GraphQLTestDirectiveTrows = new GraphQLCustomDirective({
+    GraphQLTestDirectiveThrows = new GraphQLCustomDirective({
       name: 'throws',
       description: 'throws an error after promise is resolved',
       locations: [DirectiveLocation.FIELD],
@@ -141,6 +163,19 @@ describe('GraphQLCustomDirective', () => {
     testEqual({directives, query, schema, input, expected, done});
   });
 
+  it('expected directive to handle complex argument types', done => {
+    const query = `{ value @duplicate(opts: [{againBy:2} {againBy:2}]) }`,
+      schema = `
+type Query { value: String } schema { query: Query }
+type TestOption { againBy: Int }
+`,
+      input = {value: 'test'},
+      directives = [GraphQLTestDirective],
+      expected = {value: 'test test test test test test test test'};
+
+    testEqual({directives, query, schema, input, expected, done});
+  });
+
   it('expected directive to alter execution of graphql and result null', done => {
     const query = `{ value @duplicate }`,
       directives = [GraphQLTestDirective],
@@ -155,7 +190,7 @@ describe('GraphQLCustomDirective', () => {
       passServer = true,
       directives = [
         GraphQLTestDirective,
-        GraphQLTestDirectiveTrows,
+        GraphQLTestDirectiveThrows,
         GraphQLTestDirectiveCatch,
       ];
 

--- a/test/index.js
+++ b/test/index.js
@@ -165,15 +165,26 @@ describe('GraphQLCustomDirective', () => {
 
   it('expected directive to handle complex argument types', done => {
     const query = `{ value @duplicate(opts: [{againBy:2} {againBy:2}]) }`,
-      schema = `
-type Query { value: String } schema { query: Query }
-type TestOption { againBy: Int }
-`,
+      schema = `type Query { value: String } schema { query: Query }`,
       input = {value: 'test'},
       directives = [GraphQLTestDirective],
       expected = {value: 'test test test test test test test test'};
 
     testEqual({directives, query, schema, input, expected, done});
+  });
+
+  it('expected directive to handle multiple arguments and variables', done => {
+    const query = `
+query TestVariables($by: Int) {
+  value @duplicate(by: $by, opts: [{againBy:2}])
+}`,
+      schema = 'type Query { value(input: Int): String } schema { query: Query }',
+      input = {value: 'test'},
+      variables = {by: 3},
+      directives = [GraphQLTestDirective],
+      expected = {value: 'test test test test test test'};
+
+    testEqual({schema, directives, query, input, variables, expected, done});
   });
 
   it('expected directive to alter execution of graphql and result null', done => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -21,6 +21,7 @@ const _runQuery = function({
   passServer = false,
   done,
   context,
+  variables,
 }) {
   let executionSchema = buildSchema(schema || DEFAULT_TEST_SCHEMA);
 
@@ -43,7 +44,7 @@ const _runQuery = function({
 
   applySchemaCustomDirectives(executionSchema);
 
-  return graphql(executionSchema, query, input, context);
+  return graphql(executionSchema, query, input, context, variables);
 };
 
 exports.testEqual = function({
@@ -51,6 +52,7 @@ exports.testEqual = function({
   query,
   schema,
   input,
+  variables,
   passServer = false,
   expected,
   done,
@@ -61,6 +63,7 @@ exports.testEqual = function({
     query,
     schema,
     input,
+    variables,
     passServer,
     done,
     context,


### PR DESCRIPTION
The approach of copying the directive args from the document to the args object passed to the resolver (`args[arg.name.value] = arg.value.value;`) only works for scalar argument types, because in the case of a [`ListValueNode`](https://github.com/graphql/graphql-js/blob/master/src/language/ast.js#L339) the prop is called `values`, for an `ObjectValueNode` it is `fields`, etc., and we would have to descend further into the document to gather the whole structure of the arguments in these cases. 

`graphql-js` exports a helper function [`getDirectiveValues`](https://github.com/graphql/graphql-js/blob/master/src/execution/values.js#L212) for exactly this purpose. Using this instead makes it possible for directives to accept arbitrary arguments. I also needed to rewrite `parseSchemaDirectives` to build the `DirectiveDefinitionNode`s directly from the user-provided directive configuration, because the existing implementation had some baked-in assumptions about there being a single string argument to the directive. 

